### PR TITLE
Github Issues link is broken & added two static site generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ## Static Site Generators
 
 - [StaticGen](http://www.staticgen.com/)
+- [MkDocs](https://github.com/mkdocs/mkdocs)
+- [Daux.io](https://github.com/justinwalsh/daux.io)
 
 ## Embeddable Content
 
@@ -167,7 +169,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [FormSite](https://www.formsite.com/)
 - [Formspree](http://formspree.io/)
 - [FormStack](https://www.formstack.com/)
-- [Github Issues](githubIssues.md)
+- ~~[Github Issues](githubIssues.md)~~ 
 - [Jotform](http://www.jotform.com/)
 - [MailThis](http://mailthis.to/)
 - [Sheetsu](http://sheetsu.com/) - POST and GET your data to Google Spreadsheet.


### PR DESCRIPTION
* Strikethrough text on Github issues as the link to the markdown file is not working, however, I hope you can point me in the right direction.
* Added Mkdocs & Daux.io to static site generators sections.