### PR TITLE
Added Contentful CMS to the Backends section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ## Backends
 
 - [Cloudstitch](http://www.cloudstitch.com/) - Use Google Sheets as a CMS.
+- [Contentful](https://www.contentful.com/) - API-first CMS with a markdown text editor.
 - [FireBase](https://www.firebase.com/)
 - [Hull](http://www.hull.io/)
 - [Parse] (https://parse.com/)


### PR DESCRIPTION
A number of [developers](https://medium.com/@javaporter/the-brave-new-world-of-static-sites-ba7ab41d503) and [agencies](http://carrot.is/coding/static_cms) use Contentful to power their static websites, so I thought I add it to the list.